### PR TITLE
feat: add lisan-ai component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@edunext/frontend-component-header",
-  "version": "5.0.2-alpha.1-nelp.7",
+  "version": "5.0.2-alpha.1-nelp.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edunext/frontend-component-header",
-      "version": "5.0.2-alpha.1-nelp.7",
+      "version": "5.0.2-alpha.1-nelp.8",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edunext/frontend-essentials": "^4.2.0",
+        "@edunext/frontend-essentials": "4.5.0",
         "@fortawesome/fontawesome-svg-core": "6.5.1",
         "@fortawesome/free-brands-svg-icons": "6.5.1",
         "@fortawesome/free-regular-svg-icons": "6.5.1",
@@ -2009,9 +2009,9 @@
       }
     },
     "node_modules/@edunext/frontend-essentials": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@edunext/frontend-essentials/-/frontend-essentials-4.2.0.tgz",
-      "integrity": "sha512-4L13mPnAe6zm/DClMtUcYhA1QSCBgGhXDsGHm5hmh9TqRIcvvi8W6TlBQ95gR5jjjhaO6iqAjeRCbRCyiiA1dg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@edunext/frontend-essentials/-/frontend-essentials-4.5.0.tgz",
+      "integrity": "sha512-WFbaqeE+v9FctQlKbO+UVPsaCBD+iHPVWiGF6zy8MH2nniiEZwALsxkOZdo9xJjdVGaC40TLGpf11uX+xj6LMQ==",
       "dependencies": {
         "@edx/frontend-platform": "npm:@edunext/frontend-platform@^7.1.2-alpha-nelc.1",
         "@emotion/react": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edunext/frontend-component-header",
-  "version": "5.0.2-alpha.1-nelp.7",
+  "version": "5.0.2-alpha.1-nelp.8",
   "description": "The standard header for Open edX",
   "main": "dist/index.js",
   "publishConfig": {
@@ -55,7 +55,7 @@
     "redux-saga": "1.3.0"
   },
   "dependencies": {
-    "@edunext/frontend-essentials": "^4.2.0",
+    "@edunext/frontend-essentials": "4.5.0",
     "@fortawesome/fontawesome-svg-core": "6.5.1",
     "@fortawesome/free-brands-svg-icons": "6.5.1",
     "@fortawesome/free-regular-svg-icons": "6.5.1",

--- a/src/learning-header/LearningHeader.jsx
+++ b/src/learning-header/LearningHeader.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
-import { ProfileDataModal } from '@edunext/frontend-essentials';
+import { ProfileDataModal, LisanAI } from '@edunext/frontend-essentials';
 
 import AnonymousUserMenu from './AnonymousUserMenu';
 import AuthenticatedUserDropdown from './AuthenticatedUserDropdown';
@@ -51,6 +51,7 @@ const LearningHeader = ({
           <span className="d-block m-0 font-weight-bold course-title">{courseTitle}</span>
         </div>
         <LanguageSelector />
+        {getConfig().LISAN_AI_ENABLED && (<LisanAI />)}
         {showUserDropdown && authenticatedUser && (
           <>
             <AuthenticatedUserDropdown

--- a/src/studio-header/StudioHeader.jsx
+++ b/src/studio-header/StudioHeader.jsx
@@ -2,7 +2,8 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Responsive from 'react-responsive';
 import { AppContext } from '@edx/frontend-platform/react';
-import { ensureConfig } from '@edx/frontend-platform';
+import { ensureConfig, getConfig } from '@edx/frontend-platform';
+import { LisanAI } from '@edunext/frontend-essentials';
 
 import MobileHeader from './MobileHeader';
 import HeaderBody from './HeaderBody';
@@ -37,6 +38,7 @@ const StudioHeader = ({
 
   return (
     <div className="studio-header">
+      {getConfig().LISAN_AI_ENABLED && (<LisanAI />)}
       <a className="nav-skip sr-only sr-only-focusable" href="#main">Skip to content</a>
       <Responsive maxWidth={841}>
         <MobileHeader {...props} />


### PR DESCRIPTION
# Description
feat: add lisan-ai component
This also upgrades frontend-essentials.

## How to test

Add the header in you env as module_config package.

Add this setting to enable it in the header of discussions and course-authoring.

``` python
MFE_CONFIG_OVERRIDES = {
    "discussions": {
        "LISAN_AI_CLIENT_ID": "client-id",
        "LISAN_AI_ENABLED": True,
    },
    "course-authoring": {
        "LISAN_AI_CLIENT_ID": "client-id",
        "LISAN_AI_ENABLED": True,
    }
}
```

- Check that the Lisan AI is working in discussion and course authoring.
-  removing the settings Lisan AI component is not loaded.
#### course-authoring

![image](https://github.com/user-attachments/assets/8b8c7f6e-b1a7-4766-8806-cbad2329158f)

#### Discussions

![image](https://github.com/user-attachments/assets/15492075-53e7-49fc-8e61-9cde86c9a424)

